### PR TITLE
Add first pass at ES rebalancer script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,28 @@
 # Elasticsearch Rebalancer
 
-TBC.
+A script that attempts to re-balance Elasticsearch shards by size without changing the existing balancing.
+
+By default ES balances shards over nodes by considering:
+
++ The number of shards / node
++ The number of shards / index / node
+
+Which is great if every shard is the same size, but in reality this is not the case. Without considering the size of shards (except for watermarks) it's possible to end up with some nodes almost at watermark alongside others that are almost empty. [This blog post](http://engineering.simplymeasured.com/dev-blog/2015/07/08/balancing-elasticsearch-cluster-by-shard-size.html) describes it well - this script is inspired by that project.
+
+## How does it work?
+
+The script is based around the idea of "swaps" - pairs of shards to relocate between the two nodes. Each iteration the script identifies the most-full and least-full nodes, searching through their largest/smallest shards to find a suitable swap. Ideally the `largest shard on the most-full node` and the `smallest shard on the least-full node` swap.
+
+To maintain existing ES balances, shards are only considered if the node to move to does not have any other shard from the same index. This means the shards per node and shards per index per node remain the same, so ES shouldn't do any additional rebalancing.
+
+## Usage
+
+```
+Usage: es-rebalance [OPTIONS] ES_HOST
+
+Options:
+  --iterations INTEGER  Number of iterations (swaps) to execute.
+  --attr TEXT           Node attributes in form key=value.
+  --commit              Whether to actually execute the shard reroutes.
+  --help                Show this message and exit.
+```

--- a/elasticsearch_rebalancer/__main__.py
+++ b/elasticsearch_rebalancer/__main__.py
@@ -270,7 +270,7 @@ def rebalance_elasticsearch(es_host, iterations=1, attr=None, commit=False):
             click.echo()
 
         if commit:
-            print_execute_reroutes(es_host, reroute_commands)
+            print_execute_reroutes(es_host, all_reroute_commands)
 
     except requests.HTTPError as e:
         click.echo(click.style(e.response.content, 'yellow'))

--- a/elasticsearch_rebalancer/__main__.py
+++ b/elasticsearch_rebalancer/__main__.py
@@ -258,6 +258,10 @@ def rebalance_elasticsearch(es_host, iterations=1, attr=None, commit=False):
         if commit:
             print_execute_reroutes(es_host, reroute_commands)
 
+    except requests.HTTPError as e:
+        click.echo(click.style(e.response.content, 'yellow'))
+        raise BalanceException(f'Invalid ES response: {e.response.status_code}')
+
     # Always restore the previous rebalance setting
     finally:
         if commit:

--- a/elasticsearch_rebalancer/__main__.py
+++ b/elasticsearch_rebalancer/__main__.py
@@ -24,6 +24,10 @@ class BalanceException(click.ClickException):
         super(BalanceException, self).__init__(message)
 
 
+def format_size(value):
+    return naturalsize(value, binary=True)
+
+
 def attempt_to_find_swap(nodes, shards):
     ordered_nodes, average = get_ordred_nodes_and_average_used(nodes)
     node_name_to_shards, index_to_node_names = combine_nodes_and_shards(nodes, shards)
@@ -92,8 +96,8 @@ def attempt_to_find_swap(nodes, shards):
 
     click.echo((
         '> Recommended swap for: '
-        f'{max_shard["id"]} ({naturalsize(max_shard["size_in_bytes"])}) <> '
-        f'{min_shard["id"]} ({naturalsize(min_shard["size_in_bytes"])})'
+        f'{max_shard["id"]} ({format_size(max_shard["size_in_bytes"])}) <> '
+        f'{min_shard["id"]} ({format_size(min_shard["size_in_bytes"])})'
     ))
     click.echo((
         f'  maxNode: {max_node["name"]} '

--- a/elasticsearch_rebalancer/__main__.py
+++ b/elasticsearch_rebalancer/__main__.py
@@ -128,7 +128,17 @@ def execute_reroute(es_host, reroute_commands):
 @click.option('--iterations', default=1, type=int)
 @click.option('--attr', multiple=True)
 @click.option('--commit', is_flag=True, default=False)
-def rebalance_elasticsearch(es_host, iterations, attr, commit=False):
+def rebalance_elasticsearch(es_host, iterations=1, attr=None, commit=False):
+    # Parse out any attrs
+    attrs = {}
+    if attr:
+        for a in attr:
+            try:
+                key, value = a.split('=', 1)
+            except ValueError:
+                raise BalanceException('Invalid attr, specify as key=value!')
+            attrs[key] = value
+
     click.echo()
     click.echo('# Elasticsearch Rebalancer')
     click.echo(f'> Target: {click.style(es_host, bold=True)}')
@@ -147,14 +157,6 @@ def rebalance_elasticsearch(es_host, iterations, attr, commit=False):
                 ', would not continue with --commit!\n'
             )
 
-    # Parse out attrs
-    attrs = {}
-    for a in attr:
-        try:
-            key, value = a.split('=', 1)
-        except ValueError:
-            raise BalanceException('Invalid attr, specify as key=value!')
-        attrs[key] = value
 
     click.echo('Loading nodes...')
     nodes = get_node_fs_stats(es_host, attrs=attrs)

--- a/elasticsearch_rebalancer/__main__.py
+++ b/elasticsearch_rebalancer/__main__.py
@@ -19,7 +19,7 @@ class BalanceException(click.ClickException):
 
 def attempt_to_find_swap(nodes, shards):
     ordered_nodes, average = get_ordred_notes_and_average_used(nodes)
-    node_name_to_shards, shard_id_to_node_names = combine_nodes_and_shards(nodes, shards)
+    node_name_to_shards, index_to_node_names = combine_nodes_and_shards(nodes, shards)
 
     for node in reversed(ordered_nodes):  # biggest to smallest node
         if node['name'] in node_name_to_shards:
@@ -48,7 +48,7 @@ def attempt_to_find_swap(nodes, shards):
     min_node_shards = node_name_to_shards[min_node['name']]
 
     for shard in reversed(max_node_shards):  # biggest to smallest shard
-        if min_node['name'] not in shard_id_to_node_names[shard['id']]:
+        if min_node['name'] not in index_to_node_names[shard['index']]:
             max_shard = shard
             break
     else:
@@ -58,7 +58,7 @@ def attempt_to_find_swap(nodes, shards):
         ))
 
     for shard in min_node_shards:
-        if max_node['name'] not in shard_id_to_node_names[shard['id']]:
+        if max_node['name'] not in index_to_node_names[shard['index']]:
             min_shard = shard
             break
     else:

--- a/elasticsearch_rebalancer/__main__.py
+++ b/elasticsearch_rebalancer/__main__.py
@@ -164,9 +164,23 @@ def print_execute_reroutes(es_host, commands):
 
 @click.command()
 @click.argument('es_host')
-@click.option('--iterations', default=1, type=int)
-@click.option('--attr', multiple=True)
-@click.option('--commit', is_flag=True, default=False)
+@click.option(
+    '--iterations',
+    default=1,
+    type=int,
+    help='Number of iterations (swaps) to execute.',
+)
+@click.option(
+    '--attr',
+    multiple=True,
+    help='Node attributes in form key=value.',
+)
+@click.option(
+    '--commit',
+    is_flag=True,
+    default=False,
+    help='Whether to actually execute the shard reroutes.',
+)
 def rebalance_elasticsearch(es_host, iterations=1, attr=None, commit=False):
     # Parse out any attrs
     attrs = {}

--- a/elasticsearch_rebalancer/__main__.py
+++ b/elasticsearch_rebalancer/__main__.py
@@ -103,6 +103,8 @@ def attempt_to_find_swap(nodes, shards):
     ))
 
     return [
+        # Note: it's important that the large shard is moved off the full-er node
+        # first in the case where we have to do them one by one.
         {
             'move': {
                 'index': max_shard['index'],

--- a/elasticsearch_rebalancer/__main__.py
+++ b/elasticsearch_rebalancer/__main__.py
@@ -8,7 +8,7 @@ from .util import (
     combine_nodes_and_shards,
     es_request,
     get_node_fs_stats,
-    get_ordred_notes_and_average_used,
+    get_ordred_nodes_and_average_used,
     get_shards,
 )
 
@@ -18,7 +18,7 @@ class BalanceException(click.ClickException):
 
 
 def attempt_to_find_swap(nodes, shards):
-    ordered_nodes, average = get_ordred_notes_and_average_used(nodes)
+    ordered_nodes, average = get_ordred_nodes_and_average_used(nodes)
     node_name_to_shards, index_to_node_names = combine_nodes_and_shards(nodes, shards)
 
     for node in reversed(ordered_nodes):  # biggest to smallest node

--- a/elasticsearch_rebalancer/__main__.py
+++ b/elasticsearch_rebalancer/__main__.py
@@ -1,0 +1,186 @@
+import click
+import requests
+
+from humanize import naturalsize
+
+from .util import (
+    check_es_cluster_health,
+    combine_nodes_and_shards,
+    es_request,
+    get_node_fs_stats,
+    get_ordred_notes_and_average_used,
+    get_shards,
+)
+
+
+class BalanceException(click.ClickException):
+    pass
+
+
+def attempt_to_find_swap(nodes, shards):
+    ordered_nodes, average = get_ordred_notes_and_average_used(nodes)
+    node_name_to_shards, shard_id_to_node_names = combine_nodes_and_shards(nodes, shards)
+
+    for node in reversed(ordered_nodes):  # biggest to smallest node
+        if node['name'] in node_name_to_shards:
+            max_node = node
+            break
+    else:
+        raise BalanceException('Could not find max node with shards!')
+
+    for node in ordered_nodes:
+        if node['name'] in node_name_to_shards:
+            min_node = node
+            break
+    else:
+        raise BalanceException('Could not find min node with shards!')
+
+    min_used = min_node['used_percent']
+    max_used = max_node['used_percent']
+    spread_used = round(max_used - min_used, 2)
+
+    click.echo((
+        f'> Disk used over {len(nodes)} nodes: '
+        f'average={average}%, min={min_used}%, max={max_used}%, spread={spread_used}%'
+    ))
+
+    max_node_shards = node_name_to_shards[max_node['name']]
+    min_node_shards = node_name_to_shards[min_node['name']]
+
+    for shard in reversed(max_node_shards):  # biggest to smallest shard
+        if min_node['name'] not in shard_id_to_node_names[shard['id']]:
+            max_shard = shard
+            break
+    else:
+        raise BalanceException((
+            'Could not find suitable large shard to move to '
+            f'{min_node["name"]}!'
+        ))
+
+    for shard in min_node_shards:
+        if max_node['name'] not in shard_id_to_node_names[shard['id']]:
+            min_shard = shard
+            break
+    else:
+        raise BalanceException((
+            'Could not find suitable small shard to move to '
+            f'{max_node["name"]}!'
+        ))
+
+    old_min_percent = min_node['used_percent']
+    old_max_percent = max_node['used_percent']
+
+    # Update the shard + node info for the next iteration
+    max_shard['node'] = min_node['name']
+    min_node['used_bytes'] += max_shard['size_in_bytes'] - min_shard['size_in_bytes']
+    min_node['used_percent'] = round(
+        min_node['used_bytes'] / min_node['total_bytes'] * 100, 2,
+    )
+
+    min_shard['node'] = max_node['name']
+    max_node['used_bytes'] += min_shard['size_in_bytes'] - max_shard['size_in_bytes']
+    max_node['used_percent'] = round(
+        max_node['used_bytes'] / max_node['total_bytes'] * 100, 2,
+    )
+
+    click.echo((
+        '> Recommended swap for: '
+        f'{max_shard["id"]} ({naturalsize(max_shard["size_in_bytes"])}) <> '
+        f'{min_shard["id"]} ({naturalsize(min_shard["size_in_bytes"])})'
+    ))
+    click.echo((
+        f'  maxNode: {max_node["name"]} '
+        f'({old_max_percent}% -> {max_node["used_percent"]}%)'
+    ))
+    click.echo((
+        f'  minNode: {min_node["name"]} '
+        f'({old_min_percent}% -> {min_node["used_percent"]}%)'
+    ))
+
+    return [
+        {
+            'move': {
+                'index': max_shard['index'],
+                'shard': max_shard['shard'],
+                'from_node': max_node['name'],
+                'to_node': min_node['name'],
+            },
+        },
+        {
+            'move': {
+                'index': min_shard['index'],
+                'shard': min_shard['shard'],
+                'from_node': min_node['name'],
+                'to_node': max_node['name'],
+            },
+        },
+    ]
+
+
+def execute_reroute(es_host, reroute_commands):
+    es_request(es_host, '_cluster/reroute', method=requests.post, json={
+        'commands': reroute_commands,
+    })
+
+
+@click.command()
+@click.argument('es_host')
+@click.option('--iterations', default=1, type=int)
+@click.option('--attr', multiple=True)
+@click.option('--commit', is_flag=True, default=False)
+def rebalance_elasticsearch(es_host, iterations, attr, commit=False):
+    click.echo()
+    click.echo('# Elasticsearch Rebalancer')
+    click.echo(f'> Target: {click.style(es_host, bold=True)}')
+    click.echo()
+
+    # Don't continue if we're not green and relocating nothing!
+    try:
+        check_es_cluster_health(es_host)
+    except Exception as e:
+        if commit:
+            raise BalanceException(e)
+        else:
+            click.echo(
+                f'{click.style("Warning", bold=True)}: '
+                f'{click.style(f"{e}", "yellow")}'
+                ', would not continue with --commit!\n'
+            )
+
+    # Parse out attrs
+    attrs = {}
+    for a in attr:
+        try:
+            key, value = a.split('=', 1)
+        except ValueError:
+            raise BalanceException('Invalid attr, specify as key=value!')
+        attrs[key] = value
+
+    click.echo('Loading nodes...')
+    nodes = get_node_fs_stats(es_host, attrs=attrs)
+    click.echo(f'> Found {len(nodes)} nodes')
+    click.echo()
+
+    click.echo('Loading shards...')
+    shards = get_shards(es_host, attrs=attrs)
+    click.echo(f'> Found {len(shards)} shards')
+    click.echo()
+
+    if not nodes:
+        raise BalanceException(
+            f'No nodes found!',
+        )
+
+    click.echo(f'Investigating rebalance options...')
+
+    for i in range(iterations):
+        click.echo(f'> Iteration {i}')
+        reroute_commands = attempt_to_find_swap(nodes, shards)
+        if reroute_commands and commit:
+            execute_reroute(es_host, reroute_commands)
+
+        click.echo()
+
+
+if __name__ == '__main__':
+    rebalance_elasticsearch()

--- a/elasticsearch_rebalancer/util.py
+++ b/elasticsearch_rebalancer/util.py
@@ -105,15 +105,15 @@ def get_ordred_notes_and_average_used(nodes):
 
 def combine_nodes_and_shards(nodes, shards):
     node_name_to_shards = defaultdict(list)
-    shard_id_to_node_names = defaultdict(list)
+    index_to_node_names = defaultdict(list)
 
     for shard in shards:
         node_name_to_shards[shard['node']].append(shard)
-        shard_id_to_node_names[shard['id']].append(shard['node'])
+        index_to_node_names[shard['index']].append(shard['node'])
 
     node_name_to_shards = {
         key: sorted(shards, key=lambda shard: shard['size_in_bytes'])
         for key, shards in node_name_to_shards.items()
     }
 
-    return node_name_to_shards, shard_id_to_node_names
+    return node_name_to_shards, index_to_node_names

--- a/elasticsearch_rebalancer/util.py
+++ b/elasticsearch_rebalancer/util.py
@@ -60,7 +60,7 @@ def execute_reroute_commands(es_host, commands):
     })
 
 
-def get_transient_cluster_setting(es_host, path):
+def get_transient_cluster_setting(es_host, path, default=None):
     attrs = path.split('.')
     settings = get_cluster_settings(es_host)
 
@@ -68,7 +68,7 @@ def get_transient_cluster_setting(es_host, path):
     for attr in attrs:
         value = value.get(attr)
         if not value:
-            return
+            return default
     return value
 
 

--- a/elasticsearch_rebalancer/util.py
+++ b/elasticsearch_rebalancer/util.py
@@ -129,7 +129,10 @@ def get_shards(es_host, attrs=None):
     filtered_shards = []
 
     for shard in shards:
-        if shard['index'] not in filtered_index_names:
+        if (
+            shard['state'] != 'STARTED'
+            or shard['index'] not in filtered_index_names
+        ):
             continue
 
         shard['id'] = f'{shard["index"]}-{shard["shard"]}'

--- a/elasticsearch_rebalancer/util.py
+++ b/elasticsearch_rebalancer/util.py
@@ -89,7 +89,7 @@ def get_shards(es_host, attrs=None):
     return filtered_shards
 
 
-def get_ordred_notes_and_average_used(nodes):
+def get_ordred_nodes_and_average_used(nodes):
     sum_total_bytes = 0
     sum_used_bytes = 0
 

--- a/elasticsearch_rebalancer/util.py
+++ b/elasticsearch_rebalancer/util.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from time import sleep
 
 import requests
 
@@ -41,6 +42,16 @@ def check_es_cluster_health(es_host):
     if relocating_shards > 0:
         raise Exception(f'ES is already relocating {relocating_shards} shards!')
 
+
+def wait_for_no_relocations(es_host):
+    while True:
+        health = get_cluster_health(es_host)
+
+        relocating_shards = health['relocating_shards']
+        if not relocating_shards:
+            break
+
+        sleep(10)
 
 def get_transient_cluster_setting(es_host, path):
     attrs = path.split('.')

--- a/elasticsearch_rebalancer/util.py
+++ b/elasticsearch_rebalancer/util.py
@@ -53,6 +53,13 @@ def wait_for_no_relocations(es_host):
 
         sleep(10)
 
+
+def execute_reroute_commands(es_host, commands):
+    es_request(es_host, '_cluster/reroute', method=requests.post, json={
+        'commands': commands,
+    })
+
+
 def get_transient_cluster_setting(es_host, path):
     attrs = path.split('.')
     settings = get_cluster_settings(es_host)

--- a/elasticsearch_rebalancer/util.py
+++ b/elasticsearch_rebalancer/util.py
@@ -19,7 +19,6 @@ def es_request(es_host, endpoint, method=requests.get, **kwargs):
     try:
         response.raise_for_status()
     except requests.HTTPError:
-        print(response.content)
         raise
 
     return response.json()

--- a/elasticsearch_rebalancer/util.py
+++ b/elasticsearch_rebalancer/util.py
@@ -14,7 +14,13 @@ def es_request(es_host, endpoint, method=requests.get, **kwargs):
         f'http://{es_host}/{endpoint}',
         **kwargs,
     )
-    response.raise_for_status()
+
+    try:
+        response.raise_for_status()
+    except requests.HTTPError:
+        print(response.content)
+        raise
+
     return response.json()
 
 

--- a/elasticsearch_rebalancer/util.py
+++ b/elasticsearch_rebalancer/util.py
@@ -1,0 +1,119 @@
+from collections import defaultdict
+
+import requests
+
+
+def es_request(es_host, endpoint, method=requests.get, **kwargs):
+    response = method(
+        f'http://{es_host}/{endpoint}',
+        **kwargs,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def matches_attrs(attrs, match_attrs):
+    match_attrs = match_attrs or {}
+    attrs = attrs or {}
+    return attrs == match_attrs
+
+
+def check_es_cluster_health(es_host):
+    health = es_request(es_host, '_cluster/health')
+    if health['status'] != 'green':
+        raise Exception('ES is not green!')
+
+    relocating_shards = health['relocating_shards']
+    if relocating_shards > 0:
+        raise Exception(f'ES is already relocating {relocating_shards} shards!')
+
+
+def get_node_fs_stats(es_host, attrs=None):
+    nodes = es_request(es_host, f'_nodes/stats/fs')['nodes']
+    filtered_nodes = []
+
+    for node_id, node_data in nodes.items():
+        if not matches_attrs(node_data.get('attributes'), attrs):
+            continue
+
+        node_data['id'] = node_id
+        stats = node_data['fs']['total']
+        node_data['used_bytes'] = stats['total_in_bytes'] - stats['available_in_bytes']
+        node_data['total_bytes'] = stats['total_in_bytes']
+
+        node_data['used_percent'] = round(
+            node_data['used_bytes'] / node_data['total_bytes'] * 100, 2,
+        )
+
+        filtered_nodes.append(node_data)
+    return filtered_nodes
+
+
+def get_shards(es_host, attrs=None):
+    indices = es_request(es_host, '_settings')
+
+    filtered_index_names = []
+
+    for index_name, index_data in indices.items():
+        index_settings = index_data['settings']['index']
+        index_attrs = (
+            index_settings
+            .get('routing', {})
+            .get('allocation', {})
+            .get('require', {})
+        )
+        if not matches_attrs(index_attrs, attrs):
+            continue
+
+        filtered_index_names.append(index_name)
+
+    shards = es_request(
+        es_host, '_cat/shards',
+        params={
+            'format': 'json',
+            'bytes': 'b',
+        },
+    )
+
+    filtered_shards = []
+
+    for shard in shards:
+        if shard['index'] not in filtered_index_names:
+            continue
+
+        shard['id'] = f'{shard["index"]}-{shard["shard"]}'
+        shard['size_in_bytes'] = int(shard['store'])
+
+        filtered_shards.append(shard)
+
+    return filtered_shards
+
+
+def get_ordred_notes_and_average_used(nodes):
+    sum_total_bytes = 0
+    sum_used_bytes = 0
+
+    for node in nodes:
+        sum_total_bytes += node['total_bytes']
+        sum_used_bytes += node['used_bytes']
+
+    average_used_percentage = round(sum_used_bytes / sum_total_bytes * 100, 2)
+
+    ordered_nodes = sorted(nodes, key=lambda node: node['used_percent'])
+    return ordered_nodes, average_used_percentage
+
+
+def combine_nodes_and_shards(nodes, shards):
+    node_name_to_shards = defaultdict(list)
+    shard_id_to_node_names = defaultdict(list)
+
+    for shard in shards:
+        node_name_to_shards[shard['node']].append(shard)
+        shard_id_to_node_names[shard['id']].append(shard['node'])
+
+    node_name_to_shards = {
+        key: sorted(shards, key=lambda shard: shard['size_in_bytes'])
+        for key, shards in node_name_to_shards.items()
+    }
+
+    return node_name_to_shards, shard_id_to_node_names

--- a/elasticsearch_rebalancer/util.py
+++ b/elasticsearch_rebalancer/util.py
@@ -33,8 +33,9 @@ def get_cluster_settings(es_host):
     return es_request(es_host, '_cluster/settings')
 
 
-def check_es_cluster_health(es_host):
-    health = es_request(es_host, '_cluster/health')
+def check_cluster_health(es_host):
+    health = get_cluster_health(es_host)
+
     if health['status'] != 'green':
         raise Exception('ES is not green!')
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,30 @@
+from setuptools import setup
+
+REQUIREMENTS = (
+    'click',
+    'humanize',
+    'requests',
+)
+
+
+if __name__ == '__main__':
+    setup(
+        name='elasticsearch-rebalancer',
+        description='Internal tool for ES index/alias creation',
+        version='0.1',
+        author='EDITED devs',
+        author_email='dev@edited.com',
+        packages=[
+            'elasticsearch_rebalancer',
+        ],
+        url='https://github.com/EDITD/elasticsearch-rebalancer',
+        install_requires=REQUIREMENTS,
+        entry_points={
+            'console_scripts': (
+                (
+                    'elasticsearch-rebalance='
+                    'elasticsearch_rebalancer.__main__:rebalance_elasticsearch'
+                ),
+            ),
+        },
+    )

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ if __name__ == '__main__':
         entry_points={
             'console_scripts': (
                 (
-                    'elasticsearch-rebalance='
+                    'es-rebalance='
                     'elasticsearch_rebalancer.__main__:rebalance_elasticsearch'
                 ),
             ),


### PR DESCRIPTION
This script helps poke an Elasticsearch cluster into balancing itself sensibly - ie considering _both_ shard size and count, rather than the default and naive count only based balancing. Inspried by [tempest](https://github.com/datarank/tempest). Works like so:

+ fetches list of nodes/shards matching any given attributes (or ones with no attributes)
+ picks the most full and most empty nodes
+ finds the largest shard on the full node and smallest shard on the empty node
+ swaps them using cluster reroute (assuming `--commit` is passed)

Even after using this ES _still_ tries to rebalance after even though the counts haven't changed at all (balancing shards per index). Can potentially be fixed by disabling rebalance.